### PR TITLE
truncate path if part of current page

### DIFF
--- a/LogseqNamespaceAbbreviator.js
+++ b/LogseqNamespaceAbbreviator.js
@@ -8,7 +8,7 @@ function getAbbreviation(text) {
     .join("")
 }
 
-function abbreviate(text) {
+function abbreviate(text, currentPage) {
   const chars = Array.from(text)
   let abbreviatedLink = ''
   chars.forEach( (char, i) => {
@@ -26,6 +26,9 @@ function abbreviate(text) {
 
       // Add page icon from the map, or the abbreviation of the page/subpage
       abbreviatedLink += `${pageIcons.get(pageName) || getAbbreviation(pageName.split('/').at(-1))}/`
+      if (pageName === currentPage) {
+        abbreviatedLink = './'
+      }
     }
   })
 
@@ -49,6 +52,8 @@ function abbreviateNamespace(selector) {
   appContainer.addEventListener("mouseenter", handleNamespaceHover, true);
   appContainer.addEventListener("mouseleave", handleNamespaceHover, true);
 
+  const currentPage = logseq.api.get_current_page()
+
   const observer = new MutationObserver((mutationList) => {
     for (const mutation of mutationList) {
       for (const node of mutation.addedNodes) {
@@ -63,7 +68,7 @@ function abbreviateNamespace(selector) {
             : text.toLowerCase();
           if (testText !== namespaceRef.dataset.ref) continue;
 
-          const abbreviatedText = abbreviate(text);
+          const abbreviatedText = abbreviate(text, currentPage?.originalName);
 
           namespaceRef.dataset.origText = text;
           namespaceRef.dataset.abbreviatedText = abbreviatedText;


### PR DESCRIPTION
 show "./" in place of the current page name. For example if I'm on "Travel/Destinations/San Francisco" and I have links to "Travel/Destinations/San Francisco/Favorites/Restaurants" etc. It truncates, replacing the current page path to "./" and then abbreviates/iconizes the rest of the path.  "Travel/Destinations/San Francisco/Favorites/Restaurants"  turns into "./⭐️/Restaurants"